### PR TITLE
#11 - fixed p. Variables in Stack code block with heap.malloc

### DIFF
--- a/paper.tex
+++ b/paper.tex
@@ -337,13 +337,15 @@ This code can be mapped to the following EO code:
   p.block > @
     8
     [b] (b.as-int > @)
-[p] > f
+[] > f
   seq > @
-    heap.malloc 16 > stack
-    long64 (stack.pointer 0 8) > b
-    b.write 7
-    long64 (stack.pointer 8 8) > a
-    a.write 42
+    malloc. > stack
+      heap 32 > h
+      16
+    long64 stack > b
+    b.write (7.as-bytes)
+    long64 stack > a
+    a.write (42.as-bytes)
     long64 (a.p.sub 1) > ret!
     h.free stack
     ret


### PR DESCRIPTION
I fixed code block in p. Variables in Stack. Here is my test:
```
[] > test
  [p] > long64
    p.block > @
      8
      [b] (b.as-int > @)
  [] > f
    seq > @
      malloc. > stack
        heap 32 > h
        16
      long64 stack > b
      b.write (7.as-bytes)
      long64 stack > a
      a.write (42.as-bytes)
      long64 (a.p.sub 1) > ret!
      h.free stack
      ret
  assert-that > @
    f
    $.equal-to 0

```